### PR TITLE
Add ability to specify multiple editors. A link for each editor is rendered.

### DIFF
--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -67,8 +67,12 @@ module BetterErrors
     end
 
   private
-    def editor_url(frame)
-      BetterErrors.editor[frame.filename, frame.line]
+    def editor_url(editor, frame)
+      editor[frame.filename, frame.line]
+    end
+
+    def editor_name(editor, frame)
+      editor_url(editor, frame)[/\A(.*?):\/\//, 1]  # Just return the URL protocol
     end
 
     def rack_session

--- a/lib/better_errors/templates/variable_info.erb
+++ b/lib/better_errors/templates/variable_info.erb
@@ -1,7 +1,16 @@
 <header class="trace_info clearfix">
     <div class="title">
         <h2 class="name"><%= @frame.name %></h2>
-        <div class="location"><span class="filename"><a href="<%= editor_url(@frame) %>"><%= @frame.pretty_path %></a></span></div>
+        <div class="location">
+          <% if BetterErrors.editors.length == 1 %><%# Show original style URL when only one editor is given %>
+            <span class="filename"><a href="<%= editor_url(BetterErrors.editors.first, @frame) %>"><%= @frame.pretty_path %></a></span>
+          <% else %>
+            <span class="filename"><%= @frame.pretty_path %></span>
+            <% BetterErrors.editors.each do |editor| %><%# Display a link for each editor defined %>
+              <a href="<%= editor_url(editor, @frame) %>">[ <%= editor_name(editor, @frame) %> ]</a>
+            <% end %>
+          <% end %>
+        </div>
     </div>
     <div class="code_block clearfix">
         <%== html_formatted_code_block @frame %>

--- a/spec/better_errors_spec.rb
+++ b/spec/better_errors_spec.rb
@@ -3,38 +3,38 @@ require "spec_helper"
 describe BetterErrors do
   context ".editor" do
     it "defaults to textmate" do
-      subject.editor["foo.rb", 123].should == "txmt://open?url=file://foo.rb&line=123"
+      subject.editors.first["foo.rb", 123].should == "txmt://open?url=file://foo.rb&line=123"
     end
 
     it "url escapes the filename" do
-      subject.editor["&.rb", 0].should == "txmt://open?url=file://%26.rb&line=0"
+      subject.editors.first["&.rb", 0].should == "txmt://open?url=file://%26.rb&line=0"
     end
 
     [:emacs, :emacsclient].each do |editor|
       it "uses emacs:// scheme when set to #{editor.inspect}" do
         subject.editor = editor
-        subject.editor[].should start_with "emacs://"
+        subject.editors.first[].should start_with "emacs://"
       end
     end
 
     [:macvim, :mvim].each do |editor|
       it "uses mvim:// scheme when set to #{editor.inspect}" do
         subject.editor = editor
-        subject.editor[].should start_with "mvim://"
+        subject.editors.first[].should start_with "mvim://"
       end
     end
 
     [:sublime, :subl, :st].each do |editor|
       it "uses subl:// scheme when set to #{editor.inspect}" do
         subject.editor = editor
-        subject.editor[].should start_with "subl://"
+        subject.editors.first[].should start_with "subl://"
       end
     end
 
     [:textmate, :txmt, :tm].each do |editor|
       it "uses txmt:// scheme when set to #{editor.inspect}" do
         subject.editor = editor
-        subject.editor[].should start_with "txmt://"
+        subject.editors.first[].should start_with "txmt://"
       end
     end
 
@@ -42,7 +42,7 @@ describe BetterErrors do
       it "uses emacs:// scheme when EDITOR=#{editor}" do
         ENV["EDITOR"] = editor
         subject.editor = subject.default_editor
-        subject.editor[].should start_with "emacs://"
+        subject.editors.first[].should start_with "emacs://"
       end
     end
 
@@ -50,15 +50,15 @@ describe BetterErrors do
       it "uses mvim:// scheme when EDITOR=#{editor}" do
         ENV["EDITOR"] = editor
         subject.editor = subject.default_editor
-        subject.editor[].should start_with "mvim://"
+        subject.editors.first[].should start_with "mvim://"
       end
     end
 
     ["subl -w", "/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"].each do |editor|
-      it "uses mvim:// scheme when EDITOR=#{editor}" do
+      it "uses subl:// scheme when EDITOR=#{editor}" do
         ENV["EDITOR"] = editor
         subject.editor = subject.default_editor
-        subject.editor[].should start_with "subl://"
+        subject.editors.first[].should start_with "subl://"
       end
     end
 
@@ -66,8 +66,15 @@ describe BetterErrors do
       it "uses txmt:// scheme when EDITOR=#{editor}" do
         ENV["EDITOR"] = editor
         subject.editor = subject.default_editor
-        subject.editor[].should start_with "txmt://"
+        subject.editors.first[].should start_with "txmt://"
       end
+    end
+
+    it "returns multiple URLs when set to a collection of editors" do
+      subject.editors = [:macvim, "emacs://open?url=file://%{file}&line=%{line}", Proc.new { |file, line| "subl://open?url=file://%{file}&line=%{line}" }]
+      subject.editors[0][].should start_with "mvim://"
+      subject.editors[1][].should start_with "emacs://"
+      subject.editors[2][].should start_with "subl://"
     end
   end
 end


### PR DESCRIPTION
@charliesome  My goal was to submit this with minimal code changes (easy to review) and preserve backwards compatibility so that users would not need to change their BetterErrors config. If you are interested in merging this then I'd like to continue develop the multiple-editor support. Thanks for the great gem.

![better-errors-multiple-editors](https://cloud.githubusercontent.com/assets/29266/4099182/686d332c-3050-11e4-81e1-4c4e86431c04.jpg)
- Support multiple editors.
- Use original link when only 1 editor is specified.
- Update existing specs.
- Rename methods to reflect plurality; add aliases for backwards compatibility.
- Update and add specs.
