### PR TITLE
Set backtrace correctly for Coffeelint errors

### DIFF
--- a/lib/better_errors/raised_exception.rb
+++ b/lib/better_errors/raised_exception.rb
@@ -51,7 +51,7 @@ module BetterErrors
 
     def massage_syntax_error
       case exception.class.to_s
-      when "Haml::SyntaxError"
+      when "Haml::SyntaxError", "Sprockets::Coffeelint::Error"
         if /\A(.+?):(\d+)/ =~ exception.backtrace.first
           backtrace.unshift(StackFrame.new($1, $2.to_i, ""))
         end

--- a/spec/better_errors/raised_exception_spec.rb
+++ b/spec/better_errors/raised_exception_spec.rb
@@ -48,5 +48,25 @@ module BetterErrors
         subject.backtrace.first.line.should == 123
       end
     end
+
+    context "when the exception is a Coffeelint syntax error" do
+      before do
+        stub_const("Sprockets::Coffeelint::Error", Class.new(SyntaxError))
+      end
+
+      let(:exception) {
+        Sprockets::Coffeelint::Error.new("[stdin]:11:88: error: unexpected=").tap do |ex|
+          ex.set_backtrace(["app/assets/javascripts/files/index.coffee:11", "sprockets/coffeelint.rb:3"])
+        end
+      }
+
+      its(:message) { should == "[stdin]:11:88: error: unexpected=" }
+      its(:type)    { should == Sprockets::Coffeelint::Error }
+
+      it "has the right filename and line number in the backtrace" do
+        subject.backtrace.first.filename.should == "app/assets/javascripts/files/index.coffee"
+        subject.backtrace.first.line.should == 11
+      end
+    end
   end
 end


### PR DESCRIPTION
After this update the backtrace will display the correct file with contents.

![sprockets__coffeelint__error_at__](https://cloud.githubusercontent.com/assets/222/5681435/9640b3c0-97e6-11e4-830e-b763fa8a194f.png)
