### PR TITLE
Consolidate newlines in exception messages to avoid blank output

### DIFF
--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -58,6 +58,14 @@ module BetterErrors
       exception.backtrace
     end
 
+    def exception_type
+      exception.type
+    end
+
+    def exception_message
+      exception.message.lstrip
+    end
+
     def application_frames
       backtrace_frames.select(&:application?)
     end

--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -115,7 +115,7 @@ module BetterErrors
     def log_exception
       return unless BetterErrors.logger
 
-      message = "\n#{@error_page.exception.type} - #{@error_page.exception.message}:\n"
+      message = "\n#{@error_page.exception_type} - #{@error_page.exception_message}:\n"
       @error_page.backtrace_frames.each do |frame|
         message << "  #{frame}\n"
       end

--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title><%= exception.type %> at <%= request_path %></title>
+    <title><%= exception_type %> at <%= request_path %></title>
 </head>
 <body>
     <%# Stylesheets are placed in the <body> for Turbolinks compatibility. %>
@@ -731,8 +731,8 @@
 
     <div class='top'>
         <header class="exception">
-            <h2><strong><%= exception.type %></strong> <span>at <%= request_path %></span></h2>
-            <p><%= exception.message %></p>
+            <h2><strong><%= exception_type %></strong> <span>at <%= request_path %></span></h2>
+            <p><%= exception_message %></p>
         </header>
     </div>
 

--- a/lib/better_errors/templates/text.erb
+++ b/lib/better_errors/templates/text.erb
@@ -1,6 +1,6 @@
-<%== text_heading("=", "%s at %s" % [exception.type, request_path]) %>
+<%== text_heading("=", "%s at %s" % [exception_type, request_path]) %>
 
-> <%== exception.message %>
+> <%== exception_message %>
 <% if backtrace_frames.any? %>
 
 <%== text_heading("-", "%s, line %i" % [first_frame.pretty_path, first_frame.line]) %>

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -72,5 +72,21 @@ module BetterErrors
       ])
       response.should include("Source unavailable")
     end
+
+    context 'with an exception with blank lines' do
+      class SpacedError < StandardError
+        def initialize(message = nil)
+          message = "\n\n#{message}" if message
+          super
+        end
+      end
+
+      let!(:exception) { raise SpacedError, "Danger Warning!" rescue $! }
+
+      it 'should not include leading blank lines from exception_message' do
+        exception.message.should =~ /\A\n\n/
+        error_page.exception_message.should_not =~ /\A\n\n/
+      end
+    end
   end
 end


### PR DESCRIPTION
The exception message will now have leading newlines removed to avoid displaying a blank message as a header.

I took the way the error message is constructed from ActiveRecord's MigrationError error class and wrote a test case mimicking it.

Fixes #313 