### PR TITLE
Use exception#cause if available (MRI Ruby 2.1+)

### DIFF
--- a/lib/better_errors/raised_exception.rb
+++ b/lib/better_errors/raised_exception.rb
@@ -4,7 +4,9 @@ module BetterErrors
     attr_reader :exception, :message, :backtrace
 
     def initialize(exception)
-      if exception.respond_to?(:original_exception) && exception.original_exception
+      if exception.respond_to?(:cause) && exception.cause
+        exception = exception.cause
+      elsif exception.respond_to?(:original_exception) && exception.original_exception
         exception = exception.original_exception
       end
 


### PR DESCRIPTION
# original_exception is deprecated in Rails 5 in favor of #cause (see rails/rails#18774).
