### PR TITLE
Fix issues with pry version >= 0.10

### DIFF
--- a/lib/better_errors/repl/pry.rb
+++ b/lib/better_errors/repl/pry.rb
@@ -30,6 +30,10 @@ module BetterErrors
         ensure
           @buffer = ""
         end
+
+        def print(*args)
+          @buffer << args.join(' ')
+        end
       end
 
       def initialize(binding)


### PR DESCRIPTION
Fixes for newer `pry` versions. Also enables `last_exception` support for calls like `wtf?`.

For reference: https://github.com/charliesome/better_errors/issues/293

Let me know if I can do anything else. Cheers.
