### PR TITLE
Make hitting tab key focus on the console

### DIFF
--- a/lib/better_errors/templates/variable_info.erb
+++ b/lib/better_errors/templates/variable_info.erb
@@ -11,7 +11,7 @@
         <div class="repl">
             <div class="console">
                 <pre></pre>
-                <div class="prompt"><span>&gt;&gt;</span> <input/></div>
+                <div class="prompt"><span>&gt;&gt;</span> <input tabindex="1"/></div>
             </div>
         </div>
     <% end %>


### PR DESCRIPTION
So that users don't have to find the console prompt with their mouse, they can just hit tab.
