### PR TITLE
Use Rails BacktraceCleaner to log errors if it's defined

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -116,7 +116,13 @@ module BetterErrors
       return unless BetterErrors.logger
 
       message = "\n#{@error_page.exception_type} - #{@error_page.exception_message}:\n"
-      @error_page.backtrace_frames.each do |frame|
+      traces = if defined?(Rails) && defined?(Rails.backtrace_cleaner)
+        Rails.backtrace_cleaner.clean(@error_page.backtrace_frames.map {|frame| "#{frame}"})
+      else
+        @error_page.backtrace_frames
+      end
+
+      traces.each do |frame|
         message << "  #{frame}\n"
       end
 


### PR DESCRIPTION
After installed `better_errors` gem in Rails app, the settings in backtrace cleaner won't work in the console. Issue #308 was talked about this.

Tried to introduce Rails BacktraceCleaner if possible.
