### PR TITLE
Hide variables unless we have binding_of_caller

### DIFF
--- a/lib/better_errors/templates/variable_info.erb
+++ b/lib/better_errors/templates/variable_info.erb
@@ -45,26 +45,28 @@
     </div>
 </div>
 
-<div class="sub">
-    <h3>Local Variables</h3>
-    <div class='inset variables'>
-        <table class="var_table">
-            <% @frame.local_variables.each do |name, value| %>
-                <tr><td class="name"><%= name %></td><td><pre><%== inspect_value value %></pre></td></tr>
-            <% end %>
-        </table>
+<% if BetterErrors.binding_of_caller_available? && @frame.frame_binding %>
+    <div class="sub">
+        <h3>Local Variables</h3>
+        <div class='inset variables'>
+            <table class="var_table">
+                <% @frame.local_variables.each do |name, value| %>
+                    <tr><td class="name"><%= name %></td><td><pre><%== inspect_value value %></pre></td></tr>
+                <% end %>
+            </table>
+        </div>
     </div>
-</div>
 
-<div class="sub">
-    <h3>Instance Variables</h3>
-    <div class="inset variables">
-        <table class="var_table">
-            <% @frame.instance_variables.each do |name, value| %>
-                <tr><td class="name"><%= name %></td><td><pre><%== inspect_value value %></pre></td></tr>
-            <% end %>
-        </table>
+    <div class="sub">
+        <h3>Instance Variables</h3>
+        <div class="inset variables">
+            <table class="var_table">
+                <% @frame.instance_variables.each do |name, value| %>
+                    <tr><td class="name"><%= name %></td><td><pre><%== inspect_value value %></pre></td></tr>
+                <% end %>
+            </table>
+        </div>
     </div>
-</div>
 
-<!-- <%= Time.now.to_f - @var_start_time %> seconds -->
+    <!-- <%= Time.now.to_f - @var_start_time %> seconds -->
+<% end %>


### PR DESCRIPTION
We can't show variables without the frame, as stated in the message under the code snippet, so there's no point displaying these sections.

At the moment it just looks like there are no variables.