### PR TITLE
Remove surrounding whitespace from exception message output

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -732,7 +732,7 @@
     <div class='top'>
         <header class="exception">
             <h2><strong><%= exception_type %></strong> <span>at <%= request_path %></span></h2>
-            <p><%= exception_message %></p>
+            <p><%= exception_message.strip %></p>
         </header>
     </div>
 


### PR DESCRIPTION
This resolves the issue of messages that have extra lines of whitespace above them, resulting in a blank black box at the top of the better errors error page.

# Before

![screen shot 2016-10-12 at 2 36 27 pm](https://cloud.githubusercontent.com/assets/908365/19323043/502ff3da-9089-11e6-951c-83faa62b25b3.png)


# After
![screen shot 2016-10-12 at 2 35 49 pm](https://cloud.githubusercontent.com/assets/908365/19323017/37f98a92-9089-11e6-9651-3596e919a8b5.png)
