### PR TITLE
Better selection background color for exception's message

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -170,6 +170,14 @@
         color: white;
     }
 
+    header.exception p::-moz-selection {
+        background: rgba(255, 255, 255, 0.1);
+    }
+
+    header.exception p::selection {
+        background: rgba(255, 255, 255, 0.1);
+    }
+
     header.exception:hover {
         height: auto;
         z-index: 2;


### PR DESCRIPTION
When trying to select(to copy) the exception's message, the default background color is too dark make difficult to see the selected text.

After fixed:
![selected_exception_message_after](https://cloud.githubusercontent.com/assets/4715931/19794900/bafc946a-9d00-11e6-8eaa-474b090b58a4.png)
