### PR TITLE
RSpec 2.14 isn't compatible with Rake 12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "rake"
+gem "rake", "< 12"
 gem "rack", "1.6.4"
 gem "rspec", "2.14.1"
 gem "binding_of_caller", platforms: :ruby


### PR DESCRIPTION
Stacktrace from Travis:

    NoMethodError: undefined method `last_comment' for #<Rake::Application:0x00000001c1e070>
    /home/travis/build/charliesome/better_errors/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/rake_task.rb:118:in `initialize'
    /home/travis/build/charliesome/better_errors/Rakefile:5:in `new'
    /home/travis/build/charliesome/better_errors/Rakefile:5:in `block in <top (required)>'
    /home/travis/build/charliesome/better_errors/Rakefile:4:in `<top (required)>'

Another options would be to upgrade RSpec: #365.