### PR TITLE
Fix issue with variable fetch call in Hanami

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -777,7 +777,7 @@
 
     function apiCall(method, opts, cb) {
         var req = new XMLHttpRequest();
-        req.open("POST", <%== uri_prefix.gsub("<", "&lt;").inspect %> + "/__better_errors/" + OID + "/" + method, true);
+        req.open("POST", "//" + window.location.host + <%== uri_prefix.gsub("<", "&lt;").inspect %> + "/__better_errors/" + OID + "/" + method, true);
         req.setRequestHeader("Content-Type", "application/json");
         req.send(JSON.stringify(opts));
         req.onreadystatechange = function() {


### PR DESCRIPTION
Faced the problem when tried to use better errors with hanami. This issue happens only on root path: `http://localhost:3000/` and the reason is that hanami returns rack's `SCRIPT_NAME` equal to pathname:

- `http://example.com/` --> `env["SCRIPT_NAME"] # => "/"`
- `http://example.com/foo` --> `env["SCRIPT_NAME"] # => "/foo"`
- `http://example.com/foo/` --> `env["SCRIPT_NAME"] # => "/foo/"`
