### PR TITLE
Add missing Emacs editor preset values to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ to troubleshoot an issue in development.
 
 ```ruby
 # e.g. in config/initializers/better_errors.rb
-# Other preset values are [:mvim, :macvim, :textmate, :txmt, :tm, :sublime, :subl, :st]
+# Other preset values are [:emacs, :emacsclient, :mvim, :macvim, :textmate, :txmt, :tm, :sublime, :subl, :st]
 BetterErrors.editor = :mvim
 ```
 


### PR DESCRIPTION
I struggled a bit to find out how to hook up better_errors to my
Emacs. Realised that the README didn't mention how to do this but that
it was supported, so I added the relevant preset values