### PR TITLE
Move `allow_ip!` calls to the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,27 +37,13 @@ _Note: If you discover that Better Errors isn't working - particularly after upg
 
 ## Security
 
-**NOTE:** It is *critical* you put better\_errors in the **development** section. **Do NOT run better_errors in production, or on Internet facing hosts.**
+**NOTE:** It is *critical* you put better\_errors only in the **development** section of your Gemfile.
+**Do NOT run better_errors in production, or on Internet-facing hosts.**
 
-You will notice that the only machine that gets the Better Errors page is localhost, which means you get the default error page if you are developing on a remote host (or a virtually remote host, such as a Vagrant box). Obviously, the REPL is not something you want to expose to the public, but there may also be other pieces of sensitive information available in the backtrace.
+You will notice that the only machine that gets the Better Errors page is localhost, which means you get the default error page if you are developing on a remote host (or a virtually remote host, such as a Vagrant box).
+Obviously, the REPL is not something you want to expose to the public, and there may be sensitive information available in the backtrace.
 
-To poke selective holes in this security mechanism, you can add a line like this to your startup (for example, on Rails it would be `config/environments/development.rb`)
-
-```ruby
-BetterErrors::Middleware.allow_ip! ENV['TRUSTED_IP'] if ENV['TRUSTED_IP']
-```
-
-Then run Rails like this:
-
-```shell
-TRUSTED_IP=66.68.96.220 rails s
-```
-
-Note that the `allow_ip!` is actually backed by a `Set`, so you can add more than one IP address or subnet.
-
-**Tip:** You can find your apparent IP by hitting the old error page's "Show env dump" and looking at "REMOTE_ADDR".
-
-**VirtualBox:** If you are using VirtualBox and are accessing the guest from your host's browser, you will need to use `allow_ip!` to see the error page.
+For more information on how to configure access, see [the wiki](https://github.com/charliesome/better_errors/wiki/Allowing-access-to-the-console).
 
 ## Usage
 
@@ -88,10 +74,11 @@ Better Errors will render a plain text error page  when the request is an
 
 ### Unicorn, Puma, and other multi-worker servers
 
-Better Errors works by leaving a lot of context in server process memory. If
-you're using a web server that runs multiple "workers" it's likely that a second
+Better Errors works by leaving a lot of context in server process memory.
+If you're using a web server that runs multiple "workers" it's likely that a second
 request (as happens when you click on a stack frame) will hit a different
-worker. That worker won't have the necessary context in memory, and you'll see
+worker.
+That worker won't have the necessary context in memory, and you'll see
 a `Session Expired` message.
 
 If this is the case for you, consider turning the number of workers to one (1)


### PR DESCRIPTION
The readme had an incomplete set of instructions for configuring allow IP addresses. Rather than adding more details to the readme, I moved much of the detail to the wiki page.

Of course, the security warning is intact on the readme, though I tightened the phrasing slightly.
