### PR TITLE
Spec syntax cleanup

### DIFF
--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -83,7 +83,7 @@ module BetterErrors
 
       let!(:exception) { raise SpacedError, "Danger Warning!" rescue $! }
 
-      it 'should not include leading blank lines from exception_message' do
+      it 'does not include leading blank lines in exception_message' do
         expect(exception.message).to match(/\A\n\n/)
         expect(error_page.exception_message).not_to match(/\A\n\n/)
       end

--- a/spec/better_errors/middleware_spec.rb
+++ b/spec/better_errors/middleware_spec.rb
@@ -67,7 +67,7 @@ module BetterErrors
       it 'does not attempt to use ActionDispatch::ExceptionWrapper with a nil exception' do
         ad_ew = double("ActionDispatch::ExceptionWrapper")
         stub_const('ActionDispatch::ExceptionWrapper', ad_ew)
-        ad_ew.should_not_receive :new
+        expect(ad_ew).to_not receive :new
 
         status, headers, body = app.call("PATH_INFO" => "/__better_errors")
       end

--- a/spec/better_errors/raised_exception_spec.rb
+++ b/spec/better_errors/raised_exception_spec.rb
@@ -6,23 +6,23 @@ module BetterErrors
     let(:exception) { RuntimeError.new("whoops") }
     subject { RaisedException.new(exception) }
 
-    its(:exception) { should == exception }
-    its(:message)   { should == "whoops" }
-    its(:type)      { should == RuntimeError }
+    its(:exception) { is_expected.to eq exception }
+    its(:message)   { is_expected.to eq "whoops" }
+    its(:type)      { is_expected.to eq RuntimeError }
 
     context "when the exception wraps another exception" do
       let(:original_exception) { RuntimeError.new("something went wrong!") }
       let(:exception) { double(:original_exception => original_exception) }
 
-      its(:exception) { should == original_exception }
-      its(:message)   { should == "something went wrong!" }
+      its(:exception) { is_expected.to eq original_exception }
+      its(:message)   { is_expected.to eq "something went wrong!" }
     end
 
     context "when the exception is a syntax error" do
       let(:exception) { SyntaxError.new("foo.rb:123: you made a typo!") }
 
-      its(:message) { should == "you made a typo!" }
-      its(:type)    { should == SyntaxError }
+      its(:message) { is_expected.to eq "you made a typo!" }
+      its(:type)    { is_expected.to eq SyntaxError }
 
       it "has the right filename and line number in the backtrace" do
         expect(subject.backtrace.first.filename).to eq("foo.rb")
@@ -41,8 +41,8 @@ module BetterErrors
         end
       }
 
-      its(:message) { should == "you made a typo!" }
-      its(:type)    { should == Haml::SyntaxError }
+      its(:message) { is_expected.to eq "you made a typo!" }
+      its(:type)    { is_expected.to eq Haml::SyntaxError }
 
       it "has the right filename and line number in the backtrace" do
         expect(subject.backtrace.first.filename).to eq("foo.rb")
@@ -61,8 +61,8 @@ module BetterErrors
         end
       }
 
-      its(:message) { should == "[stdin]:11:88: error: unexpected=" }
-      its(:type)    { should == Sprockets::Coffeelint::Error }
+      its(:message) { is_expected.to eq "[stdin]:11:88: error: unexpected=" }
+      its(:type)    { is_expected.to eq Sprockets::Coffeelint::Error }
 
       it "has the right filename and line number in the backtrace" do
         expect(subject.backtrace.first.filename).to eq("app/assets/javascripts/files/index.coffee")


### PR DESCRIPTION
- Remove the last few `should` syntax calls.
- Fix a spec description that was oddly written