### PR TITLE
Leave extraneous files out of the gem

### DIFF
--- a/better_errors.gemspec
+++ b/better_errors.gemspec
@@ -12,8 +12,10 @@ Gem::Specification.new do |s|
   s.homepage      = "https://github.com/charliesome/better_errors"
   s.license       = "MIT"
 
-  s.files         = `git ls-files`.split($/)
-  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+  s.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^((test|spec|features|feature-screenshots)/|Rakefile)})
+  end
+
   s.require_paths = ["lib"]
 
   s.required_ruby_version = ">= 2.0.0"


### PR DESCRIPTION
Currently we're packaging the test files and all of the screenshot images added for the wiki.

I copied the way that the bundler gem creator does `files`. And I removed `test_files`, since it [seems to be undesirable](https://stackoverflow.com/a/20927191/1589422).