### PR TITLE
Fix blank frame info area when variable fetch returns error

### DIFF
--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -125,7 +125,11 @@ module BetterErrors
 
     def internal_call(env, opts)
       if opts[:id] != @error_page.id
-        return [200, { "Content-Type" => "text/plain; charset=utf-8" }, [JSON.dump(error: "Session expired")]]
+        return [200, { "Content-Type" => "text/plain; charset=utf-8" }, [JSON.dump(
+          error: "Session expired",
+          explanation: "This page was likely opened from a previous exception, " +
+            "and the exception is no longer available in memory.",
+        )]]
       end
 
       env["rack.input"].rewind

--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -141,6 +141,9 @@ module BetterErrors
       explanation = if defined? Middleman
         "Middleman reloads all dependencies for each request, " +
           "which breaks Better Errors."
+      elsif defined?(Shotgun) && defined?(Hanami)
+        "Hanami is likely running with code-reloading enabled, which is the default. " +
+          "You can disable this by running hanami with the `--no-code-reloading` option."
       elsif defined? Shotgun
         "The shotgun gem causes everything to be reloaded for every request. " +
           "You can disable shotgun in the Gemfile temporarily to use Better Errors."

--- a/lib/better_errors/middleware.rb
+++ b/lib/better_errors/middleware.rb
@@ -124,6 +124,14 @@ module BetterErrors
     end
 
     def internal_call(env, opts)
+      unless @error_page
+        return [200, { "Content-Type" => "text/plain; charset=utf-8" }, [JSON.dump(
+          error: 'No exception information available',
+          explanation: "The application has been restarted since this page loaded. " +
+            "If you didn't do this, the project likely includes a gem like shotgun, " +
+            "which reloads all gems for each request.",
+        )]]
+      end
       if opts[:id] != @error_page.id
         return [200, { "Content-Type" => "text/plain; charset=utf-8" }, [JSON.dump(
           error: "Session expired",

--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -938,7 +938,11 @@
             apiCall("variables", { "index": index }, function(response) {
                 el.loaded = true;
                 if(response.error) {
-                    el.innerHTML = "<span class='error'>" + escapeHTML(response.error) + "</span>";
+                    el.innerHTML = "<h2 class='error'>" + escapeHTML(response.error) + "</h2>";
+                    if(response.explanation) {
+                      el.innerHTML += "<p class='explanation'>" + escapeHTML(response.explanation) + "</p>";
+                    }
+                    el.innerHTML += "<p><a target='_new' href='https://github.com/charliesome/better_errors'>More about Better Errors</a></p>";
                 } else {
                     el.innerHTML = response.html;
 
@@ -946,9 +950,8 @@
                     if(repl) {
                         new REPL(index).install(repl);
                     }
-
-                    switchTo(el);
                 }
+                switchTo(el);
             });
         }
     }

--- a/spec/better_errors/middleware_spec.rb
+++ b/spec/better_errors/middleware_spec.rb
@@ -219,9 +219,18 @@ module BetterErrors
 
         context 'when Shotgun is in use' do
           let!(:shotgun) { class_double("Shotgun").as_stubbed_const }
+
           it 'returns a JSON error' do
             expect(json_body['explanation'])
               .to match(/The shotgun gem/)
+          end
+
+          context 'when Hanami is also in use' do
+            let!(:hanami) { class_double("Hanami").as_stubbed_const }
+            it 'returns a JSON error' do
+              expect(json_body['explanation'])
+                .to match(/--no-code-reloading/)
+            end
           end
         end
       end

--- a/spec/better_errors/middleware_spec.rb
+++ b/spec/better_errors/middleware_spec.rb
@@ -208,6 +208,22 @@ module BetterErrors
             'explanation' => /application has been restarted/,
           )
         end
+
+        context 'when Middleman is in use' do
+          let!(:middleman) { class_double("Middleman").as_stubbed_const }
+          it 'returns a JSON error' do
+            expect(json_body['explanation'])
+              .to match(/Middleman reloads all dependencies/)
+          end
+        end
+
+        context 'when Shotgun is in use' do
+          let!(:shotgun) { class_double("Shotgun").as_stubbed_const }
+          it 'returns a JSON error' do
+            expect(json_body['explanation'])
+              .to match(/The shotgun gem/)
+          end
+        end
       end
 
       context 'when an error has been recorded' do

--- a/spec/better_errors/middleware_spec.rb
+++ b/spec/better_errors/middleware_spec.rb
@@ -184,5 +184,58 @@ module BetterErrors
         app.call({})
       end
     end
+
+    context "requesting the variables for a specific frame" do
+      let(:env) { {} }
+      let(:result) {
+        app.call(
+          "PATH_INFO" => "/__better_errors/#{id}/#{method}",
+          # This is a POST request, and this is the body of the request.
+          "rack.input" => StringIO.new('{"index": 0}'),
+        )
+      }
+      let(:status) { result[0] }
+      let(:headers) { result[1] }
+      let(:body) { result[2].join }
+      let(:json_body) { JSON.parse(body) }
+      let(:id) { 'abcdefg' }
+      let(:method) { 'variables' }
+
+      context 'when no errors have been recorded' do
+        it 'returns a JSON error' do
+          expect(json_body).to match(
+            'error' => 'No exception information available',
+            'explanation' => /application has been restarted/,
+          )
+        end
+      end
+
+      context 'when an error has been recorded' do
+        let(:error_page) { ErrorPage.new(exception, env) }
+        before do
+          app.instance_variable_set('@error_page', error_page)
+        end
+
+        context 'but it does not match the request' do
+          it 'returns a JSON error' do
+            expect(json_body).to match(
+              'error' => 'Session expired',
+              'explanation' => /no longer available in memory/,
+            )
+          end
+        end
+
+        context 'and it matches the request', :focus do
+          let(:id) { error_page.id }
+
+          it 'returns a JSON error' do
+            expect(error_page).to receive(:do_variables).and_return(html: "<content>")
+            expect(json_body).to match(
+              'html' => '<content>',
+            )
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently if the variable fetch fails, it displays a blank area on the page, no indication of failure.

<img alt="showint the blank frame after failure" src="https://user-images.githubusercontent.com/1005280/28758448-e506b36a-7565-11e7-9637-804473930113.png"/>

It was parsing the error that came in the response, and placing it in the correct frame, but it wasn't activating the frame so that it was visible. I fixed this.

I then added some more information about the error, including a link to the Better Errors project.

<img alt="showing the Session Expired error" src="https://user-images.githubusercontent.com/1005280/28759053-30daecc0-7566-11e7-9cde-9dc73c426a40.png"/>

Finally, I added error messages to help those dealing with failures like #301, mostly caused by shotgun or another code-reloading technique. This should give them enough information to have Better Errors working if possible.

<img alt="the error shown when shotgun is enabled" src="https://user-images.githubusercontent.com/1005280/28763735-3c1bd52c-758e-11e7-9a47-d2ac4a89e957.png">

If Hanami is in use:

<img alt="the error shown when Hanami is in use" src="https://user-images.githubusercontent.com/1005280/28763685-e78e217c-758d-11e7-840b-f6a271a33629.png">

If Middleman is in use:

<img width="1089" alt="the error shown when Middleman is in use" src="https://user-images.githubusercontent.com/1005280/28763800-a7ed38fe-758e-11e7-81e5-d54ffd9023b8.png">
