### PR TITLE
Switch from erubis to erubi

### DIFF
--- a/better_errors.gemspec
+++ b/better_errors.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_dependency "erubis", ">= 2.6.6"
+  s.add_dependency "erubi", ">= 1.0.0"
   s.add_dependency "coderay", ">= 1.0.0"
   s.add_dependency "rack", ">= 0.9.0"
 

--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -1,5 +1,5 @@
 require "pp"
-require "erubis"
+require "erubi"
 require "coderay"
 require "uri"
 

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -10,7 +10,7 @@ module BetterErrors
     end
 
     def self.template(template_name)
-      Erubis::EscapedEruby.new(File.read(template_path(template_name)))
+      Erubi::Engine.new(File.read(template_path(template_name)), escape: true)
     end
 
     attr_reader :exception, :env, :repls
@@ -27,7 +27,7 @@ module BetterErrors
     end
 
     def render(template_name = "main")
-      self.class.template(template_name).result binding
+      binding.eval(self.class.template(template_name).src)
     end
 
     def do_variables(opts)


### PR DESCRIPTION
Rails has [switched to erubi](https://github.com/rails/rails/pull/27757) for what seem like good reasons: 

- Works with Ruby's `--enable-frozen-string-literal` option
- Has 88% smaller memory footprint
- Does no freedom patching (Erubis adds a method to Kernel)
- Has simpler internals (1 file, <150 lines of code)
- Has an open development model (Erubis doesn't have a public source control repository or bug tracker)
- Is not dead (Erubis hasn't been updated since 2011)

Since Rails has switched, switching the dependency in Better Errors means one fewer dependency for most users. There doesn't seem to be any downside.

This completes #377.