### PR TITLE
Fix Pry `uninitialized constant` exception

### DIFF
--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -45,9 +45,9 @@ module BetterErrors
         return { error: "REPL unavailable in this stack frame" }
       end
 
-      @repls[index] ||= get_repl(index, binding)
+      @repls[index] ||= REPL.provider.new(binding, exception)
 
-      send_input(index, code)
+      eval_and_respond(index, code)
     end
 
     def backtrace_frames
@@ -111,19 +111,7 @@ module BetterErrors
       "<span class='unsupported'>(exception was raised in inspect)</span>"
     end
 
-    def get_repl(index, binding)
-      REPL.provider.new(binding).tap do |repl|
-        if repl.is_a?(REPL::Pry)
-          pry = repl.instance_variable_get(:@pry)
-          pry.instance_variable_set(
-            :@last_exception,
-            ::Pry::LastException.new(@exception.exception)
-          )
-        end
-      end
-    end
-
-    def send_input(index, code)
+    def eval_and_respond(index, code)
       result, prompt, prefilled_input = @repls[index].send_input(code)
 
       {

--- a/lib/better_errors/repl.rb
+++ b/lib/better_errors/repl.rb
@@ -21,7 +21,9 @@ module BetterErrors
     end
 
     def self.test_provider(provider)
-      require provider[:impl]
+      # We must load this file instead of `require`ing it, since during our tests we want the file
+      # to be reloaded. In practice, this will only be called once, so `require` is not necessary.
+      load "#{provider[:impl]}.rb"
       true
     rescue LoadError
       false

--- a/lib/better_errors/repl/basic.rb
+++ b/lib/better_errors/repl/basic.rb
@@ -1,7 +1,7 @@
 module BetterErrors
   module REPL
     class Basic
-      def initialize(binding)
+      def initialize(binding, _exception)
         @binding = binding
       end
 

--- a/lib/better_errors/repl/pry.rb
+++ b/lib/better_errors/repl/pry.rb
@@ -36,7 +36,7 @@ module BetterErrors
         end
       end
 
-      def initialize(binding)
+      def initialize(binding, exception)
         @fiber = Fiber.new do
           @pry.repl binding
         end
@@ -44,7 +44,13 @@ module BetterErrors
         @output = BetterErrors::REPL::Pry::Output.new
         @pry = ::Pry.new input: @input, output: @output
         @pry.hooks.clear_all if defined?(@pry.hooks.clear_all)
+        store_last_exception exception
         @fiber.resume
+      end
+
+      def store_last_exception(exception)
+        return unless defined? ::Pry::LastException
+        @pry.instance_variable_set(:@last_exception, ::Pry::LastException.new(exception.exception))
       end
 
       def send_input(str)

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -113,6 +113,37 @@ module BetterErrors
           )
         end
       end
+
+      context 'with Pry enabled' do
+        before do
+          BetterErrors.use_pry!
+          # Cause the provider to be unselected, so that it will be re-detected.
+          BetterErrors::REPL.provider = nil
+        end
+        after do
+          BetterErrors::REPL::PROVIDERS.shift
+          BetterErrors::REPL.provider = nil
+
+          # Ensure the Pry REPL file has not been included. If this is not done,
+          # the constant leaks into other examples.
+          BetterErrors::REPL.send(:remove_const, :Pry)
+        end
+
+        it "evaluates the code" do
+          BetterErrors::REPL.provider
+          do_eval
+          expect(eval_tester).to have_received(:stuff_was_done).with(:yep)
+        end
+
+        it 'returns a hash of the code and its result' do
+          expect(do_eval).to include(
+            highlighted_input: /stuff_was_done/,
+            prefilled_input: '',
+            prompt: '>>',
+            result: "=> \"response\"\n",
+          )
+        end
+      end
     end
   end
 end

--- a/spec/better_errors/repl/basic_spec.rb
+++ b/spec/better_errors/repl/basic_spec.rb
@@ -10,7 +10,9 @@ module BetterErrors
         binding
       }
 
-      let(:repl) { Basic.new fresh_binding }
+      let!(:exception) { raise ZeroDivisionError, "you divided by zero you silly goose!" rescue $! }
+
+      let(:repl) { Basic.new(fresh_binding, exception) }
 
       it_behaves_like "a REPL provider"
     end

--- a/spec/better_errors/repl/pry_spec.rb
+++ b/spec/better_errors/repl/pry_spec.rb
@@ -1,11 +1,21 @@
 require "spec_helper"
 require "pry"
-require "better_errors/repl/pry"
 require "better_errors/repl/shared_examples"
 
 module BetterErrors
   module REPL
     describe Pry do
+      before(:all) do
+        load "better_errors/repl/pry.rb"
+      end
+      after(:all) do
+        # Ensure the Pry REPL file has not been included. If this is not done,
+        # the constant leaks into other examples.
+        # In practice, this constant is only defined if `use_pry!` is called and then the
+        # REPL is used, causing BetterErrors::REPL to require the file.
+        BetterErrors::REPL.send(:remove_const, :Pry)
+      end
+
       let(:fresh_binding) {
         local_a = 123
         binding

--- a/spec/better_errors/repl/pry_spec.rb
+++ b/spec/better_errors/repl/pry_spec.rb
@@ -11,7 +11,9 @@ module BetterErrors
         binding
       }
 
-      let(:repl) { Pry.new fresh_binding }
+      let!(:exception) { raise ZeroDivisionError, "you divided by zero you silly goose!" rescue $! }
+
+      let(:repl) { Pry.new(fresh_binding, exception) }
 
       it "does line continuation" do
         output, prompt, filled = repl.send_input ""


### PR DESCRIPTION
This fixes #393.

The fix in #329 placed some code that was specific to `REPL::Pry` in the `ErrorPage` class. This caused an exception to be raised _when Pry is not enabled_ because `REPL::Pry` class is only loaded after `use_pry!` is called.

To fix this exception, I moved the Pry-specific behavior into `REPL::Pry` and added a new argument to the REPL initializer containing the most recent exception.
(The code was placed in `ErrorPage` because that was the only place where the exception was available at the time.)

I also found that there were no specs covering REPL evaluation, so I added some.
The specs failed until this refactoring was applied.

# Method of loading `REPL::Pry`

I then made one further change: since this gem's tests run on Pry 0.9, the use of Pry 0.10+ features (specifically, the use of `Pry::LastException`) caused the specs to fail.
I added a conditional that fixes the spec and will keep this change from affecting users of Pry 0.9.
In order to effectively test the Pry REPL, I had to make changes to the way that it is loaded...

The file containing `REPL::Pry` can only be included when Pry is in the bundle, since it requires `'pry'`; the `REPL` class attempts to load it only during provider selection.
In order to use `REPL::Pry` in tests and not have it affect other specs, we must load it only when needed for an example, and then unload it after the example.

This is very hacky, and would be better refactored into a separate gem such as `better_errors-pry`.
This other gem would be able to specify the supported Pry version in its gemspec, which is something we avoid doing in this gem because Pry is intentionally optional.
