### PR TITLE
Fix sharing the DOM with web-console

### DIFF
--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -394,7 +394,7 @@
      * Monospace
      * --------------------------------------------------------------------- */
 
-    pre, code, .repl input, .repl .prompt span, textarea, .code_linenums {
+    pre, code, .be-repl input, .be-repl .prompt span, textarea, .code_linenums {
         font-family: menlo, lucida console, monospace;
         font-size: 8pt;
     }
@@ -460,7 +460,7 @@
         font-weight: 200;
     }
 
-    .code, .console, .unavailable {
+    .code, .be-console, .unavailable {
         background: #fff;
         padding: 5px;
 
@@ -532,13 +532,13 @@
     }
 
     /* REPL shell */
-    .console {
+    .be-console {
         padding: 0 1px 10px 1px;
         border-bottom-left-radius: 2px;
         border-bottom-right-radius: 2px;
     }
 
-    .console pre {
+    .be-console pre {
         padding: 10px 10px 0 10px;
         max-height: 400px;
         overflow-x: none;
@@ -549,29 +549,30 @@
     }
 
     /* .prompt > span + input */
-    .console .prompt {
+    .be-console .prompt {
         display: table;
         width: 100%;
     }
 
-    .console .prompt span,
-    .console .prompt input {
+    .be-console .prompt span,
+    .be-console .prompt input {
         display: table-cell;
     }
 
-    .console .prompt span {
+    .be-console .prompt span {
         width: 1%;
         padding-right: 5px;
         padding-left: 10px;
+        white-space: pre;
     }
 
-    .console .prompt input {
+    .be-console .prompt input {
         width: 99%;
     }
 
     /* Input box */
-    .console input,
-    .console input:focus {
+    .be-console input,
+    .be-console input:focus {
         outline: 0;
         border: 0;
         padding: 0;
@@ -669,14 +670,14 @@
 
     nav.sidebar::-webkit-scrollbar,
     .inset pre::-webkit-scrollbar,
-    .console pre::-webkit-scrollbar,
+    .be-console pre::-webkit-scrollbar,
     .code::-webkit-scrollbar {
         width: 10px;
         height: 10px;
     }
 
     .inset pre::-webkit-scrollbar-thumb,
-    .console pre::-webkit-scrollbar-thumb,
+    .be-console pre::-webkit-scrollbar-thumb,
     .code::-webkit-scrollbar-thumb {
         background: #ccc;
         border-radius: 5px;
@@ -692,7 +693,7 @@
         background: -webkit-linear-gradient(left, #aaa, #999);
     }
 
-    .console pre:hover::-webkit-scrollbar-thumb,
+    .be-console pre:hover::-webkit-scrollbar-thumb,
     .inset pre:hover::-webkit-scrollbar-thumb,
     .code:hover::-webkit-scrollbar-thumb {
         background: #888;
@@ -924,7 +925,7 @@
 
         el.style.display = "block";
 
-        var replInput = el.querySelector('.console input');
+        var replInput = el.querySelector('.be-console input');
         if (replInput) replInput.focus();
     }
 
@@ -946,7 +947,7 @@
                 } else {
                     el.innerHTML = response.html;
 
-                    var repl = el.querySelector(".repl .console");
+                    var repl = el.querySelector(".be-repl .be-console");
                     if(repl) {
                         new REPL(index).install(repl);
                     }

--- a/lib/better_errors/templates/main.erb
+++ b/lib/better_errors/templates/main.erb
@@ -394,7 +394,7 @@
      * Monospace
      * --------------------------------------------------------------------- */
 
-    pre, code, .be-repl input, .be-repl .prompt span, textarea, .code_linenums {
+    pre, code, .be-repl input, .be-repl .command-line span, textarea, .code_linenums {
         font-family: menlo, lucida console, monospace;
         font-size: 8pt;
     }
@@ -548,25 +548,25 @@
         white-space: pre-wrap;
     }
 
-    /* .prompt > span + input */
-    .be-console .prompt {
+    /* .command-line > span + input */
+    .be-console .command-line {
         display: table;
         width: 100%;
     }
 
-    .be-console .prompt span,
-    .be-console .prompt input {
+    .be-console .command-line span,
+    .be-console .command-line input {
         display: table-cell;
     }
 
-    .be-console .prompt span {
+    .be-console .command-line span {
         width: 1%;
         padding-right: 5px;
         padding-left: 10px;
         white-space: pre;
     }
 
-    .be-console .prompt input {
+    .be-console .command-line input {
         width: 99%;
     }
 
@@ -810,7 +810,7 @@
     REPL.prototype.install = function(containerElement) {
         this.container = containerElement;
 
-        this.promptElement  = this.container.querySelector(".prompt span");
+        this.promptElement  = this.container.querySelector(".command-line .prompt");
         this.inputElement   = this.container.querySelector("input");
         this.outputElement  = this.container.querySelector("pre");
 

--- a/lib/better_errors/templates/variable_info.erb
+++ b/lib/better_errors/templates/variable_info.erb
@@ -11,7 +11,7 @@
         <div class="be-repl">
             <div class="be-console">
                 <pre></pre>
-                <div class="prompt"><span class=''>&gt;&gt;</span> <input/></div>
+                <div class="command-line"><span class='prompt'>&gt;&gt;</span> <input/></div>
             </div>
         </div>
     <% end %>

--- a/lib/better_errors/templates/variable_info.erb
+++ b/lib/better_errors/templates/variable_info.erb
@@ -8,10 +8,10 @@
     </div>
 
     <% if BetterErrors.binding_of_caller_available? && @frame.frame_binding %>
-        <div class="repl">
-            <div class="console">
+        <div class="be-repl">
+            <div class="be-console">
                 <pre></pre>
-                <div class="prompt"><span>&gt;&gt;</span> <input/></div>
+                <div class="prompt"><span class=''>&gt;&gt;</span> <input/></div>
             </div>
         </div>
     <% end %>


### PR DESCRIPTION
If web-console is in the same page as Better Errors, web-console was taking the `.console` element in the page.

This renames it to `.be-console`.

I also renamed the `.prompt` element to `.command-line`, since it wraps the actual prompt and the input element _and_ when it was time to grab the `promptElement` it was looking for the first `span` in it anyway. So things make a little more sense.

Fixes #391.