### PR TITLE
Fix browser performance issues with configurable maximum variable size

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ Better Errors includes a link to your editor for the file and line of code that 
 By default, it uses your environment to determine which editor should be opened.
 See [the wiki for instructions on configuring the editor](https://github.com/charliesome/better_errors/wiki/Link-to-your-editor).
 
+
+##Set maximum variable size for inspector.
+
+```ruby
+# e.g. in config/initializers/better_errors.rb
+# This will stop BetterErrors from trying to render larger objects, which can cause
+# slow loading times and browser performance problems. Stated size is in characters and refers
+# to the length of #inspect's payload for the given object. Please be aware that HTML escaping
+# modifies the size of this payload so setting this limit too precisely is not recommended.  
+# default value: 100_000
+BetterErrors.maximum_variable_inspect_size = 100_000
+```
+
+
 ## Get in touch!
 
 If you're using better_errors, I'd love to hear from you. Drop me a line and tell me what you think!

--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -44,6 +44,11 @@ module BetterErrors
     # The ignored instance variables.
     # @return [Array]
     attr_accessor :ignored_instance_variables
+
+    # The maximum variable payload size. If variable.inspect exceeds this,
+    # the variable won't be returned.
+    # @return int
+    attr_accessor :maximum_variable_inspect_size
   end
   @ignored_instance_variables = []
 
@@ -142,5 +147,7 @@ begin
 rescue LoadError
   BetterErrors.binding_of_caller_available = false
 end
+
+BetterErrors.maximum_variable_inspect_size ||= 100_000
 
 require "better_errors/rails" if defined? Rails::Railtie

--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -51,6 +51,7 @@ module BetterErrors
     attr_accessor :maximum_variable_inspect_size
   end
   @ignored_instance_variables = []
+  @maximum_variable_inspect_size = 100_000
 
   # Returns a proc, which when called with a filename and line number argument,
   # returns a URL to open the filename and line in the selected editor.
@@ -147,7 +148,5 @@ begin
 rescue LoadError
   BetterErrors.binding_of_caller_available = false
 end
-
-BetterErrors.maximum_variable_inspect_size ||= 100_000
 
 require "better_errors/rails" if defined? Rails::Railtie

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -114,11 +114,18 @@ module BetterErrors
     def inspect_raw_value(obj)
       value = CGI.escapeHTML(obj.inspect)
 
-      if !BetterErrors.maximum_variable_inspect_size.nil? && value.length > BetterErrors.maximum_variable_inspect_size
-        "<span class='unsupported'>(object too large - modify #{CGI.escapeHTML(obj.class.to_s)}#inspect or raise BetterErrors.maximum_variable_inspect_size)</span>"
-      else
+      if value_small_enough_to_inspect?(value)
         value
+      else
+        "<span class='unsupported'>(object too large. "\
+          "Modify #{CGI.escapeHTML(obj.class.to_s)}#inspect "\
+          "or increase BetterErrors.maximum_variable_inspect_size)</span>"
       end
+    end
+
+    def value_small_enough_to_inspect?(value)
+      return true if BetterErrors.maximum_variable_inspect_size.nil?
+      value.length <= BetterErrors.maximum_variable_inspect_size
     end
 
     def eval_and_respond(index, code)

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -104,11 +104,21 @@ module BetterErrors
     end
 
     def inspect_value(obj)
-      CGI.escapeHTML(obj.inspect)
+      inspect_raw_value(obj)
     rescue NoMethodError
       "<span class='unsupported'>(object doesn't support inspect)</span>"
-    rescue Exception
-      "<span class='unsupported'>(exception was raised in inspect)</span>"
+    rescue Exception => e
+      "<span class='unsupported'>(exception #{CGI.escapeHTML(e.class.to_s)} was raised in inspect)</span>"
+    end
+
+    def inspect_raw_value(obj)
+      value = CGI.escapeHTML(obj.inspect)
+
+      if !BetterErrors.maximum_variable_inspect_size.nil? && value.length > BetterErrors.maximum_variable_inspect_size
+        "<span class='unsupported'>(object too large - modify #{CGI.escapeHTML(obj.class.to_s)}#inspect or raise BetterErrors.maximum_variable_inspect_size)</span>"
+      else
+        value
+      end
     end
 
     def eval_and_respond(index, code)

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -153,7 +153,7 @@ module BetterErrors
       empty_binding.instance_variable_set('@small', content)
 
       html = error_page.do_variables("index" => 0)[:html]
-      html.should_not include "object too large"
+      expect(html).to_not include("object too large")
     end
 
     it "hides variables with inspects that are above the inspect size threshold" do
@@ -163,7 +163,7 @@ module BetterErrors
       empty_binding.instance_variable_set('@big', content)
 
       html = error_page.do_variables("index" => 0)[:html]
-      html.should include "object too large"
+      expect(html).to include("object too large")
     end
 
     it "shows variables with large inspects if max inspect size is disabled" do
@@ -173,7 +173,7 @@ module BetterErrors
       empty_binding.instance_variable_set('@big', content)
 
       html = error_page.do_variables("index" => 0)[:html]
-      html.should_not include "object too large"
+      expect(html).to_not include("object too large")
     end
   end
 end

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -159,7 +159,7 @@ module BetterErrors
     it "hides variables with inspects that are above the inspect size threshold" do
       BetterErrors.maximum_variable_inspect_size = 50_000
 
-      content = 'A' * (BetterErrors.maximum_variable_inspect_size)
+      content = 'A' * BetterErrors.maximum_variable_inspect_size
       empty_binding.instance_variable_set('@big', content)
 
       html = error_page.do_variables("index" => 0)[:html]
@@ -169,7 +169,7 @@ module BetterErrors
     it "shows variables with large inspects if max inspect size is disabled" do
       BetterErrors.maximum_variable_inspect_size = nil
 
-      content = 'A' * (50_000)
+      content = 'A' * 50_000
       empty_binding.instance_variable_set('@big', content)
 
       html = error_page.do_variables("index" => 0)[:html]

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -169,7 +169,7 @@ module BetterErrors
     it "shows variables with large inspects if max inspect size is disabled" do
       BetterErrors.maximum_variable_inspect_size = nil
 
-      content = 'A' * 50_000
+      content = 'A' * 150_000
       empty_binding.instance_variable_set('@big', content)
 
       html = error_page.do_variables("index" => 0)[:html]

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -145,5 +145,35 @@ module BetterErrors
         end
       end
     end
+
+    it "shows variables with inspects that are below the inspect size threshold" do
+      BetterErrors.maximum_variable_inspect_size = 50_000
+
+      content = 'AAAAA'
+      empty_binding.instance_variable_set('@small', content)
+
+      html = error_page.do_variables("index" => 0)[:html]
+      html.should_not include "object too large"
+    end
+
+    it "hides variables with inspects that are above the inspect size threshold" do
+      BetterErrors.maximum_variable_inspect_size = 50_000
+
+      content = 'A' * (BetterErrors.maximum_variable_inspect_size)
+      empty_binding.instance_variable_set('@big', content)
+
+      html = error_page.do_variables("index" => 0)[:html]
+      html.should include "object too large"
+    end
+
+    it "shows variables with large inspects if max inspect size is disabled" do
+      BetterErrors.maximum_variable_inspect_size = nil
+
+      content = 'A' * (50_000)
+      empty_binding.instance_variable_set('@big', content)
+
+      html = error_page.do_variables("index" => 0)[:html]
+      html.should_not include "object too large"
+    end
   end
 end


### PR DESCRIPTION
Based on my comment on #334 and @tobypinder’s PR #360:

> this will allow the user to set a maximum payload size for `variable.inspect`, above which the variable is filtered out of the error page. This solves many performance problems associated with the browser being slow to render error pages, the CPU requirements for the error page skyrocketing etc.
> 
> Many variable types end up being huge like Rails collections being inspected (and therefore queried for) before they are paginated. I've set the default to 100,000 characters, but the default can be modified to unlimited by setting `BetterErrors.maximum_variable_inspect_size` to `nil`, if we think compatibility is more important than a friendly default.

Closes #360 
Closes #334