### PR TITLE
Test coverage reporting in CI

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 sudo: false
 language: ruby
 cache: bundler
+env:
+  # With this env variable, coverage information sent to coveralls will not be processed until the webhook is sent.
+  COVERALLS_PARALLEL: true
+notifications:
+  webhooks:
+    # Inform coveralls that all builds are complete. https://coveralls.zendesk.com/hc/en-us/articles/203484329-Parallel-Build-Webhook
+    - secure: "YnHYbTq51ySistjvOxsuNhyg4GLuUffEJstTYeGYXiBF7HG5h43IVYo8KNuLzwkgsOYBcNo+YMdQX7qCqJffSbhsr1FZRSzBmjFFxcyD4hu+ukM2theZ4mePVAZiePscYvQPRNY4hIb4d3egStJEytkalDhB3sOebF57tIaCssg="
 rvm:
   - 2.0.0
   - 2.1.10

--- a/gemfiles/pry010.gemfile
+++ b/gemfiles/pry010.gemfile
@@ -4,4 +4,6 @@ gem 'rack', RUBY_VERSION < '2.2.2' ? '~> 1.6' : '~> 2.0'
 gem "binding_of_caller"
 gem "pry", "~> 0.10.0"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/pry011.gemfile
+++ b/gemfiles/pry011.gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 gem 'rack', RUBY_VERSION < '2.2.2' ? '~> 1.6' : '~> 2.0'
 gem "pry", "~> 0.11.0pre"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/pry09.gemfile
+++ b/gemfiles/pry09.gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 gem 'rack', RUBY_VERSION < '2.2.2' ? '~> 1.6' : '~> 2.0'
 gem "pry", "~> 0.9.12"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/rack.gemfile
+++ b/gemfiles/rack.gemfile
@@ -2,4 +2,6 @@ source "https://rubygems.org"
 
 gem 'rack', RUBY_VERSION < '2.2.2' ? '~> 1.6' : '~> 2.0'
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/rack_boc.gemfile
+++ b/gemfiles/rack_boc.gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 gem 'rack', RUBY_VERSION < '2.2.2' ? '~> 1.6' : '~> 2.0'
 gem "binding_of_caller"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 4.2.0"
 gem 'nokogiri', RUBY_VERSION < '2.1' ? '~> 1.6.0' : '>= 1.7'
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/rails42_boc.gemfile
+++ b/gemfiles/rails42_boc.gemfile
@@ -4,4 +4,6 @@ gem "rails", "~> 4.2.0"
 gem 'nokogiri', RUBY_VERSION < '2.1' ? '~> 1.6.0' : '>= 1.7'
 gem "binding_of_caller"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/rails42_haml.gemfile
+++ b/gemfiles/rails42_haml.gemfile
@@ -4,4 +4,6 @@ gem "rails", "~> 4.2.0"
 gem 'nokogiri', RUBY_VERSION < '2.1' ? '~> 1.6.0' : '>= 1.7'
 gem "haml"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -2,4 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/rails50_boc.gemfile
+++ b/gemfiles/rails50_boc.gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 5.0.0"
 gem "binding_of_caller"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/rails50_haml.gemfile
+++ b/gemfiles/rails50_haml.gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 5.0.0"
 gem "haml"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -2,4 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/rails51_boc.gemfile
+++ b/gemfiles/rails51_boc.gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 5.1.0"
 gem "binding_of_caller"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/gemfiles/rails51_haml.gemfile
+++ b/gemfiles/rails51_haml.gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 5.1.0"
 gem "haml"
 
+gem 'coveralls', require: false
+
 gemspec path: "../"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,5 +2,10 @@ $: << File.expand_path("../../lib", __FILE__)
 
 ENV["EDITOR"] = nil
 
+require 'coveralls'
+Coveralls.wear! do
+  add_filter 'spec/'
+end
+
 require 'bundler/setup'
 Bundler.require(:default)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,14 @@ $: << File.expand_path("../../lib", __FILE__)
 
 ENV["EDITOR"] = nil
 
-require 'coveralls'
-Coveralls.wear! do
-  add_filter 'spec/'
+# Ruby 2.4.0 and 2.4.1 has a bug with its Coverage module that causes segfaults.
+# https://bugs.ruby-lang.org/issues/13305
+# 2.4.2 should include this patch.
+unless RUBY_VERSION == '2.4.0' || RUBY_VERSION == '2.4.1'
+  require 'coveralls'
+  Coveralls.wear! do
+    add_filter 'spec/'
+  end
 end
 
 require 'bundler/setup'


### PR DESCRIPTION
Add Coveralls as a development dependency. All CI builds in the main fork (including pull requests) will send coverage data to coveralls.

Each matrix build sends its own coverage data. When all builds have completed, Travis sends a webhook to Coveralls so that it can stitch all coverage data together. This allows us to see which lines are covered by any of the builds. (This project has differing behavior depending on whether Rails of binding_of_caller are included in the bundle, so this is important.)

New pull requests will receive a build status based on whether coverage increased or decreased in that PR.

Ruby 2.4.1 has a bug in its `Coverage` module, so coverage reporting is disabled for that version of Ruby. When 2.4.2 is released, the bug should be fixed, and once the Travis config is updated to use it instead of 2.4.1, coverage reporting will run in that version of Ruby.