### PR TITLE
Add support for vscode editor

### DIFF
--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -19,6 +19,7 @@ module BetterErrors
     { symbols: [:textmate, :txmt, :tm], sniff: /mate/i,  url: "txmt://open?url=file://%{file}&line=%{line}" },
     { symbols: [:idea], sniff: /idea/i, url: "idea://open?file=%{file}&line=%{line}" },
     { symbols: [:rubymine], sniff: /mine/i, url: "x-mine://open?file=%{file}&line=%{line}" },
+    { symbols: [:vscode, :code], sniff: /code/i, url: "vscode://file/%{file}:%{line}" },
   ]
 
   class << self

--- a/spec/better_errors_spec.rb
+++ b/spec/better_errors_spec.rb
@@ -85,5 +85,13 @@ describe BetterErrors do
         expect(subject.editor[]).to start_with "idea://"
       end
     end
+
+    ["vscode", "code"].each do |editor|
+      it "uses vscode:// scheme when EDITOR=#{editor}" do
+        ENV["EDITOR"] = editor
+        subject.editor = subject.default_editor
+        expect(subject.editor[]).to start_with "vscode://"
+      end
+    end
   end
 end


### PR DESCRIPTION
According the docs we can call vscode from browser: https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls. 

This PR adds VSCode support.