### PR TITLE
Add a Dockerfile for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:2.4.1-alpine
+
+# ~~~~ Set up the environment ~~~~
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN mkdir -p /gem/
+WORKDIR /gem/
+ADD . /gem/
+
+RUN apk update && \
+  apk add --no-cache git && \
+  touch ~/.gemrc && \
+  echo "gem: --no-ri --no-rdoc" >> ~/.gemrc && \
+  gem install rubygems-update && \
+  update_rubygems && \
+  gem install bundler && \
+  bundle install
+
+# Import the gem source code
+VOLUME .:/gem/
+
+ENTRYPOINT ["bundle", "exec"]
+CMD ["rake", "-T"]


### PR DESCRIPTION
The aim of this PR is to add a Dockerfile allowing anyone using Docker to work on this gem without having to install anything else than Docker on his machine.

While this make the working environment building faster, it also ensure everybody uses the same versions of the libraires and so on.

## Usage

Build the Docker image:

```bash
$ docker build -t <yourname>/better_errors .
Sending build context to Docker daemon  2.764MB
Step 1/9 : FROM ruby:2.4.1
...
Step 9/9 : CMD rake -T
 ---> Running in 36b57a0503ab
 ---> 8b4428d830f6
Removing intermediate container 36b57a0503ab
Successfully built 8b4428d830f6
Successfully tagged <yourname>/better_errors:latest
```

Look at available rake tasks:

```bash
$ docker run --rm <yourname>/better_errors
rake build                 # Build better_errors-2.4.0.gem into the pkg directory
rake clean                 # Remove any temporary products
rake clobber               # Remove any generated files
rake install               # Build and install better_errors-2.4.0.gem into system gems
rake install:local         # Build and install better_errors-2.4.0.gem into system gems without network access
rake release[remote]       # Create tag v2.4.0 and build and push better_errors-2.4.0.gem to rubygems.org
rake test                  # Run RSpec code examples
rake test:all              # Test all supported sets of dependencies
rake test:bundles:install  # Install all dependencies necessary to test
rake test:bundles:update   # Update all dependencies for tests
```

Run the full test suite:

```bash
$ docker run --rm <yourname>/better_errors rake
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.7.0/lib:/usr/local/bundle/gems/rspec-support-3.7.0/lib /usr/local/bundle/gems/rspec-core-3.7.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
Skipping Pry specs because pry is not in the bundle
...................****.......................*..............................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) BetterErrors::ErrorPage#do_eval with binding_of_caller available with Pry disabled or unavailable evaluates the code
     # Disabled without binding_of_caller
     # ./spec/better_errors/error_page_spec.rb:177

  2) BetterErrors::ErrorPage#do_eval with binding_of_caller available with Pry disabled or unavailable returns a hash of the code and its result
     # Disabled without binding_of_caller
     # ./spec/better_errors/error_page_spec.rb:182

  3) BetterErrors::ErrorPage#do_eval with binding_of_caller available with Pry enabled evaluates the code
     # Disabled without binding_of_caller
     Failure/Error: BetterErrors::REPL.send(:remove_const, :Pry)

     NameError:
       constant BetterErrors::REPL::Pry not defined
     # ./spec/better_errors/error_page_spec.rb:206:in `remove_const'
     # ./spec/better_errors/error_page_spec.rb:206:in `block (5 levels) in <module:BetterErrors>'

  4) BetterErrors::ErrorPage#do_eval with binding_of_caller available with Pry enabled returns a hash of the code and its result
     # Disabled without binding_of_caller
     Failure/Error: BetterErrors::REPL.send(:remove_const, :Pry)

     NameError:
       constant BetterErrors::REPL::Pry not defined
     # ./spec/better_errors/error_page_spec.rb:206:in `remove_const'
     # ./spec/better_errors/error_page_spec.rb:206:in `block (5 levels) in <module:BetterErrors>'

  5) BetterErrors::Middleware when handling an error the logger when Rails is being used receives the exception without filtered backtrace frames
     # Rails not included in this run
     # ./spec/better_errors/middleware_spec.rb:195

Finished in 0.12773 seconds (files took 0.13176 seconds to load)
109 examples, 0 failures, 5 pending
```

If you want to add/update the tests using the Docker image, just add the volume to your disk:

```bash
$ docker run --rm -v "$PWD":/gem <yourname>/better_errors rake
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.7.0/lib:/usr/local/bundle/gems/rspec-support-3.7.0/lib /usr/local/bundle/gems/rspec-core-3.7.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
...
Finished in 0.23215 seconds (files took 0.26805 seconds to load)
109 examples, 0 failures, 5 pending
```

Docker image size:

```bash
REPOSITORY            TAG       IMAGE ID        CREATED         SIZE
zedtux/better_errors  latest    1b8e2982b83d    2 seconds ago   113MB
```