### PR TITLE
Implemented ObjectSpace.memsize_of in inspect_raw_value

### DIFF
--- a/lib/better_errors.rb
+++ b/lib/better_errors.rb
@@ -4,6 +4,7 @@ require "coderay"
 require "uri"
 
 require "better_errors/code_formatter"
+require "better_errors/inspectable_value"
 require "better_errors/error_page"
 require "better_errors/middleware"
 require "better_errors/raised_exception"

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -1,6 +1,7 @@
 require "cgi"
 require "json"
 require "securerandom"
+require "objspace"
 
 module BetterErrors
   # @private
@@ -70,7 +71,7 @@ module BetterErrors
       application_frames.first || backtrace_frames.first
     end
 
-  private
+    private
     def editor_url(frame)
       BetterErrors.editor[frame.filename, frame.line]
     end
@@ -112,7 +113,11 @@ module BetterErrors
     end
 
     def inspect_raw_value(obj)
-      value = CGI.escapeHTML(obj.inspect)
+      if defined?(ObjectSpace.memsize_of) 
+        value =  CGI.escapeHTML(ObjectSpace.memspace_of(obj)) 
+      else
+        value = CGI.escapeHTML(obj.inspect)
+      end
 
       if value_small_enough_to_inspect?(value)
         value

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -71,7 +71,7 @@ module BetterErrors
       application_frames.first || backtrace_frames.first
     end
 
-    private
+  private
     def editor_url(frame)
       BetterErrors.editor[frame.filename, frame.line]
     end
@@ -113,11 +113,7 @@ module BetterErrors
     end
 
     def inspect_raw_value(obj)
-      if defined?(ObjectSpace.memsize_of) 
-        value =  CGI.escapeHTML(ObjectSpace.memspace_of(obj)) 
-      else
-        value = CGI.escapeHTML(obj.inspect)
-      end
+      value = CGI.escapeHTML(obj.inspect)
 
       if value_small_enough_to_inspect?(value)
         value
@@ -130,7 +126,11 @@ module BetterErrors
 
     def value_small_enough_to_inspect?(value)
       return true if BetterErrors.maximum_variable_inspect_size.nil?
-      value.length <= BetterErrors.maximum_variable_inspect_size
+      if defined?(ObjectSpace) && defined?(ObjectSpace.memsize_of) && ObjectSpace.memsize_of(value)
+        ObjectSpace.memsize_of(value) <= BetterErrors.maximum_variable_inspect_size
+      else
+        value.length <= BetterErrors.maximum_variable_inspect_size
+      end
     end
 
     def eval_and_respond(index, code)

--- a/lib/better_errors/error_page.rb
+++ b/lib/better_errors/error_page.rb
@@ -1,7 +1,6 @@
 require "cgi"
 require "json"
 require "securerandom"
-require "objspace"
 
 module BetterErrors
   # @private
@@ -71,7 +70,8 @@ module BetterErrors
       application_frames.first || backtrace_frames.first
     end
 
-  private
+    private
+
     def editor_url(frame)
       BetterErrors.editor[frame.filename, frame.line]
     end
@@ -105,32 +105,13 @@ module BetterErrors
     end
 
     def inspect_value(obj)
-      inspect_raw_value(obj)
-    rescue NoMethodError
-      "<span class='unsupported'>(object doesn't support inspect)</span>"
+      InspectableValue.new(obj).to_html
+    rescue BetterErrors::ValueLargerThanConfiguredMaximum
+      "<span class='unsupported'>(object too large. "\
+        "Modify #{CGI.escapeHTML(obj.class.name)}#inspect "\
+        "or adjust BetterErrors.maximum_variable_inspect_size)</span>"
     rescue Exception => e
       "<span class='unsupported'>(exception #{CGI.escapeHTML(e.class.to_s)} was raised in inspect)</span>"
-    end
-
-    def inspect_raw_value(obj)
-      value = CGI.escapeHTML(obj.inspect)
-
-      if value_small_enough_to_inspect?(value)
-        value
-      else
-        "<span class='unsupported'>(object too large. "\
-          "Modify #{CGI.escapeHTML(obj.class.to_s)}#inspect "\
-          "or increase BetterErrors.maximum_variable_inspect_size)</span>"
-      end
-    end
-
-    def value_small_enough_to_inspect?(value)
-      return true if BetterErrors.maximum_variable_inspect_size.nil?
-      if defined?(ObjectSpace) && defined?(ObjectSpace.memsize_of) && ObjectSpace.memsize_of(value)
-        ObjectSpace.memsize_of(value) <= BetterErrors.maximum_variable_inspect_size
-      else
-        value.length <= BetterErrors.maximum_variable_inspect_size
-      end
     end
 
     def eval_and_respond(index, code)

--- a/lib/better_errors/inspectable_value.rb
+++ b/lib/better_errors/inspectable_value.rb
@@ -19,10 +19,12 @@ module BetterErrors
     attr_reader :original_value
 
     def value
-      @value ||= if original_value.respond_to? :inspect
-        original_value.inspect
-      else
-        original_value
+      @value ||= begin
+        if original_value.respond_to? :inspect
+          original_value.inspect
+        else
+          original_value
+        end
       end
     end
 

--- a/lib/better_errors/inspectable_value.rb
+++ b/lib/better_errors/inspectable_value.rb
@@ -1,0 +1,39 @@
+require "cgi"
+require "objspace" rescue nil
+
+module BetterErrors
+  class ValueLargerThanConfiguredMaximum < StandardError; end
+
+  class InspectableValue
+    def initialize(value)
+      @original_value = value
+    end
+
+    def to_html
+      raise ValueLargerThanConfiguredMaximum unless value_small_enough_to_inspect?
+      @html ||= CGI.escapeHTML(value)
+    end
+
+    private
+
+    attr_reader :original_value
+
+    def value
+      @value ||= if original_value.respond_to? :inspect
+        original_value.inspect
+      else
+        original_value
+      end
+    end
+
+    def value_small_enough_to_inspect?
+      return true if BetterErrors.maximum_variable_inspect_size.nil?
+
+      if defined?(ObjectSpace) && defined?(ObjectSpace.memsize_of) && ObjectSpace.memsize_of(value)
+        ObjectSpace.memsize_of(value) <= BetterErrors.maximum_variable_inspect_size
+      else
+        to_html.length <= BetterErrors.maximum_variable_inspect_size
+      end
+    end
+  end
+end

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -61,7 +61,7 @@ module BetterErrors
 
         context 'when maximum_variable_inspect_size is set' do
           before do
-            BetterErrors.maximum_variable_inspect_size = 500
+            BetterErrors.maximum_variable_inspect_size = 1010
           end
 
           context 'with a variable that is not larger than maximum_variable_inspect_size' do
@@ -84,7 +84,7 @@ module BetterErrors
 
               binding
             }
-            let(:content) { 'A' * 501 }
+            let(:content) { 'A' * 1001 }
 
             it "includes an indication that the variable was too large" do
               html = error_page.do_variables("index" => 0)[:html]

--- a/spec/better_errors/error_page_spec.rb
+++ b/spec/better_errors/error_page_spec.rb
@@ -64,7 +64,7 @@ module BetterErrors
             BetterErrors.maximum_variable_inspect_size = 1010
           end
 
-          context 'with a variable that is not larger than maximum_variable_inspect_size' do
+          context 'with a variable that is smaller than maximum_variable_inspect_size' do
             let(:exception_binding) {
               @small = content
 
@@ -79,17 +79,42 @@ module BetterErrors
           end
 
           context 'with a variable that is larger than maximum_variable_inspect_size' do
-            let(:exception_binding) {
-              @big = content
+            context 'but has an #inspect that returns a smaller value' do
+              let(:exception_binding) {
+                @big = content
 
-              binding
-            }
-            let(:content) { 'A' * 1001 }
+                binding
+              }
+              let(:content) {
+                class ExtremelyLargeInspectableTestValue
+                  def initialize
+                    @a = 'A' * 1101
+                  end
+                  def inspect
+                    "shortval"
+                  end
+                end
+                InspectableTestValue.new
+              }
 
-            it "includes an indication that the variable was too large" do
-              html = error_page.do_variables("index" => 0)[:html]
-              expect(html).to_not include(content)
-              expect(html).to include("object too large")
+              it "shows the variable content" do
+                html = error_page.do_variables("index" => 0)[:html]
+                expect(html).to include("shortval")
+              end
+            end
+            context 'and does not implement #inspect' do
+              let(:exception_binding) {
+                @big = content
+
+                binding
+              }
+              let(:content) { 'A' * 1101 }
+
+              it "includes an indication that the variable was too large" do
+                html = error_page.do_variables("index" => 0)[:html]
+                expect(html).to_not include(content)
+                expect(html).to include("object too large")
+              end
             end
           end
         end


### PR DESCRIPTION
Imported the ObjectSpace library in order to use the memsize_of
when evaluating the size of a variable.

Refs: https://github.com/charliesome/better_errors/issues/412