### PR TITLE
Add MRI 2.5 and Rails 5.2 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,15 @@ gemfile:
   - gemfiles/rails42.gemfile
   - gemfiles/rails50.gemfile
   - gemfiles/rails51.gemfile
+  - gemfiles/rails52.gemfile
   - gemfiles/rails42_haml.gemfile
   - gemfiles/rails50_haml.gemfile
   - gemfiles/rails51_haml.gemfile
+  - gemfiles/rails52_haml.gemfile
   - gemfiles/rails42_boc.gemfile
   - gemfiles/rails50_boc.gemfile
   - gemfiles/rails51_boc.gemfile
+  - gemfiles/rails52_boc.gemfile
   - gemfiles/rack.gemfile
   - gemfiles/rack_boc.gemfile
   - gemfiles/pry09.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,12 @@ matrix:
       gemfile: gemfiles/rails51_boc.gemfile
     - rvm: 2.0.0
       gemfile: gemfiles/rails51_haml.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails52.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails52_boc.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/rails52_haml.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/rails50.gemfile
     - rvm: 2.1.10
@@ -64,6 +70,12 @@ matrix:
       gemfile: gemfiles/rails51_boc.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/rails51_haml.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails52.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails52_boc.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails52_haml.gemfile
     - rvm: 2.4.4
       gemfile: gemfiles/rails42.gemfile
     - rvm: 2.4.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: ruby
 cache: bundler
+before_install:
+  - gem update --system
+  - gem update bundler
 notifications:
   webhooks:
     # With COVERALLS_PARALLEL, coverage information sent to coveralls will not be processed until

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ notifications:
 rvm:
   - 2.0.0
   - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
 gemfile:
   - gemfiles/rails42.gemfile
@@ -60,9 +61,15 @@ matrix:
       gemfile: gemfiles/rails51_boc.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/rails51_haml.gemfile
-    - rvm: 2.4.1
+    - rvm: 2.4.4
       gemfile: gemfiles/rails42.gemfile
-    - rvm: 2.4.1
+    - rvm: 2.4.4
       gemfile: gemfiles/rails42_boc.gemfile
-    - rvm: 2.4.1
+    - rvm: 2.4.4
+      gemfile: gemfiles/rails42_haml.gemfile
+    - rvm: 2.5.1
+      gemfile: gemfiles/rails42.gemfile
+    - rvm: 2.5.1
+      gemfile: gemfiles/rails42_boc.gemfile
+    - rvm: 2.5.1
       gemfile: gemfiles/rails42_haml.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ notifications:
     # https://coveralls.zendesk.com/hc/en-us/articles/203484329-Parallel-Build-Webhook
     - secure: "YnHYbTq51ySistjvOxsuNhyg4GLuUffEJstTYeGYXiBF7HG5h43IVYo8KNuLzwkgsOYBcNo+YMdQX7qCqJffSbhsr1FZRSzBmjFFxcyD4hu+ukM2theZ4mePVAZiePscYvQPRNY4hIb4d3egStJEytkalDhB3sOebF57tIaCssg="
 rvm:
-  - 2.0.0
-  - 2.1.10
   - 2.2.10
   - 2.3.7
   - 2.4.4
@@ -43,42 +41,6 @@ matrix:
     - gemfile: gemfiles/pry010.gemfile
     - gemfile: gemfiles/pry011.gemfile
   exclude:
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails50_boc.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails50_haml.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails51.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails51_boc.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails51_haml.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails52.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails52_boc.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails52_haml.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails50.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails50_boc.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails50_haml.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails51.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails51_boc.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails51_haml.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails52.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails52_boc.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails52_haml.gemfile
     - rvm: 2.4.4
       gemfile: gemfiles/rails42.gemfile
     - rvm: 2.4.4

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 5.2.0"
+
+gem 'coveralls', require: false
+
+gemspec path: "../"

--- a/gemfiles/rails52_boc.gemfile
+++ b/gemfiles/rails52_boc.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 5.2.0"
+gem "binding_of_caller"
+
+gem 'coveralls', require: false
+
+gemspec path: "../"

--- a/gemfiles/rails52_haml.gemfile
+++ b/gemfiles/rails52_haml.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 5.2.0"
+gem "haml"
+
+gem 'coveralls', require: false
+
+gemspec path: "../"


### PR DESCRIPTION
- Add MRI 2.5.1 (Rails 4.x tests are excluded from this Ruby just like they are from 2.4.x.)
- Remove MRI 2.0.0 and 2.1.10. Since [2.2 is no longer supported](https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/) it seems reasonable to remove the previous two releases.
- Update to MRI 2.2.10, 2.3.7, 2.4.4
- Add Rails 5.2
