### PR TITLE
Rescue on undefined local variables in frame_binding

### DIFF
--- a/lib/better_errors/stack_frame.rb
+++ b/lib/better_errors/stack_frame.rb
@@ -76,12 +76,14 @@ module BetterErrors
         # considered a bug in Ruby itself, but we need to work around it.
         next if name == :"\#$!"
 
-        if defined?(frame_binding.local_variable_get)
-          hash[name] = frame_binding.local_variable_get(name)
-        else
-          hash[name] = frame_binding.eval(name.to_s)
-        end
+        hash[name] = local_variable(name)
       end
+    end
+
+    def local_variable(name)
+      get_local_variable(name) || eval_local_variable(name)
+    rescue NameError => ex
+      "#{ex.class}: #{ex.message}"
     end
 
     def instance_variables
@@ -113,6 +115,16 @@ module BetterErrors
         @class_name = "#{$1}#{Kernel.instance_method(:class).bind(recv).call}"
         @method_name = "##{method_name}"
       end
+    end
+
+    def get_local_variable(name)
+      if defined?(frame_binding.local_variable_get)
+        frame_binding.local_variable_get(name)
+      end
+    end
+
+    def eval_local_variable(name)
+      frame_binding.eval(name.to_s)
     end
   end
 end

--- a/spec/better_errors/stack_frame_spec.rb
+++ b/spec/better_errors/stack_frame_spec.rb
@@ -81,6 +81,26 @@ module BetterErrors
       end
     end
 
+    context "#local_variable" do
+      it "returns exception details when #get_local_variable raises NameError" do
+        frame = StackFrame.new("/abc/xyz/app/controllers/crap_controller.rb", 123, "index")
+        allow(frame).to receive(:get_local_variable).and_raise(NameError.new("details"))
+        expect(frame.local_variable("foo")).to eq("NameError: details")
+      end
+
+      it "returns exception details when #eval_local_variable raises NameError" do
+        frame = StackFrame.new("/abc/xyz/app/controllers/crap_controller.rb", 123, "index")
+        allow(frame).to receive(:eval_local_variable).and_raise(NameError.new("details"))
+        expect(frame.local_variable("foo")).to eq("NameError: details")
+      end
+
+      it "raises on non-NameErrors" do
+        frame = StackFrame.new("/abc/xyz/app/controllers/crap_controller.rb", 123, "index")
+        allow(frame).to receive(:get_local_variable).and_raise(ArgumentError)
+        expect { frame.local_variable("foo") }.to raise_error
+      end
+    end
+
     it "special cases SyntaxErrors" do
       begin
         eval(%{ raise SyntaxError, "you wrote bad ruby!" }, nil, "my_file.rb", 123)


### PR DESCRIPTION
Some local variables appear to be undefined in the frame_binding.

For example, I see errors on local variables: `m`, `args`, `block`, `r`, and `target` when inspecting an error on a class that inherits from SimpleDelegator.

Fix: Add a rescue on NameError to catch these.
Fixes issue: https://github.com/charliesome/better_errors/issues/351

Inspiration for this fix comes from @glebtv in https://github.com/glebtv/better_errors/commit/6d00365df24eb5660ab32be16728089f7fa1ae13

Example:

![better_errors_fix](https://user-images.githubusercontent.com/64674/39641692-c0d0583e-4f94-11e8-822d-2d85371268c8.png)