### PR TITLE
Fix stack overflow when ObjectSpace is not available

### DIFF
--- a/lib/better_errors/inspectable_value.rb
+++ b/lib/better_errors/inspectable_value.rb
@@ -11,12 +11,16 @@ module BetterErrors
 
     def to_html
       raise ValueLargerThanConfiguredMaximum unless value_small_enough_to_inspect?
-      @html ||= CGI.escapeHTML(value)
+      value_as_html
     end
 
     private
 
     attr_reader :original_value
+
+    def value_as_html
+      @value_as_html ||= CGI.escapeHTML(value)
+    end
 
     def value
       @value ||= begin
@@ -34,7 +38,7 @@ module BetterErrors
       if defined?(ObjectSpace) && defined?(ObjectSpace.memsize_of) && ObjectSpace.memsize_of(value)
         ObjectSpace.memsize_of(value) <= BetterErrors.maximum_variable_inspect_size
       else
-        to_html.length <= BetterErrors.maximum_variable_inspect_size
+        value_as_html.length <= BetterErrors.maximum_variable_inspect_size
       end
     end
   end


### PR DESCRIPTION
The specs added in #412 left out an edge case: when a platform is missing `ObjectSpace` support. And I introduced a bug in variable serialization [here](https://github.com/charliesome/better_errors/commit/f1c2fdc219409513cf64e8adb1f132598374ee68#diff-e322090784182380ed3a4a5f8490b2f0R35) by calling `to_html`.

So this adds a spec that covers the case of a platform without `ObjectSpace`, and it fixes the recursion introduced in my commit.